### PR TITLE
Modification of sample method of the StochasticAcceptance class

### DIFF
--- a/src/Kendrick/StochasticAcceptanceProportionalSelection.class.st
+++ b/src/Kendrick/StochasticAcceptanceProportionalSelection.class.st
@@ -31,10 +31,12 @@ StochasticAcceptanceProportionalSelection >> normalize [
 
 { #category : #accessing }
 StochasticAcceptanceProportionalSelection >> sample [
-	| x i |
+	| x i j|
+	
 	x := Random new next.
 	i := (frequencies size * x) asInteger.
+	j := ((frequencies at: i)/maxValue).
 	[ i > 0 ]
-		whileTrue: [ x >= ((frequencies at: i) quo: maxValue)
+		whileTrue: [ (x  < (j + 1))
 				ifTrue: [ ^ i ] ]
 ]

--- a/src/Kendrick/StochasticAcceptanceProportionalSelection.class.st
+++ b/src/Kendrick/StochasticAcceptanceProportionalSelection.class.st
@@ -31,12 +31,13 @@ StochasticAcceptanceProportionalSelection >> normalize [
 
 { #category : #accessing }
 StochasticAcceptanceProportionalSelection >> sample [
-	| x i j|
+
+	| i|
 	
-	x := Random new next.
-	i := (frequencies size * x) asInteger.
-	j := ((frequencies at: i)/maxValue).
+	i := ((frequencies size) * (Random new next)) asInteger. 
 	[ i > 0 ]
-		whileTrue: [ (x  < (j + 1))
-				ifTrue: [ ^ i ] ]
+		whileTrue: 
+				[ (Random new next  < (((frequencies at: i)/maxValue) ))
+					ifTrue: [ ^ i ]
+				]
 ]


### PR DESCRIPTION
When we see the implementation of the sample method of the StochasticAcceptance class we see that the ifTrue: of the whileTrue: loop will have difficulty being executed because x <j would be improbable.

Hence I propose to use an x <j + 1 in order to have a return of i