### PR TITLE
Rename remove: as removeVariable: 

### DIFF
--- a/src/Kendrick/KEBinaryExpression.class.st
+++ b/src/Kendrick/KEBinaryExpression.class.st
@@ -243,15 +243,25 @@ KEBinaryExpression >> printOn: aStream [
 		nextPutAll: rightHandSide asString
 ]
 
+{ #category : #evaluating }
+KEBinaryExpression >> removeIndexedVariable [
+	|new|
+	new := self copy.
+	new leftHandSide: (new leftHandSide removeIndexedVariable).
+	new rightHandSide: (new rightHandSide removeIndexedVariable).
+	^ new.
+
+]
+
 { #category : #removing }
-KEBinaryExpression >> remove: aVariable [
+KEBinaryExpression >> removeVariable: aVariable [
 	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
 
 	| new |
-	new := self class  new
+	new := self class new
 		op: op;
-		leftHandSide: (leftHandSide remove: aVariable);
-		rightHandSide: (rightHandSide remove: aVariable).
+		leftHandSide: (leftHandSide removeVariable: aVariable);
+		rightHandSide: (rightHandSide removeVariable: aVariable).
 	new checkNil
 		ifTrue: [ ^ nil ].
 	new leftHandSide ifNil: [ ^ rightHandSide ].
@@ -265,16 +275,6 @@ KEBinaryExpression >> remove: aVariable [
 				op: #-;
 				expression: leftHandSide ].
 	^ new
-]
-
-{ #category : #evaluating }
-KEBinaryExpression >> removeIndexedVariable [
-	|new|
-	new := self copy.
-	new leftHandSide: (new leftHandSide removeIndexedVariable).
-	new rightHandSide: (new rightHandSide removeIndexedVariable).
-	^ new.
-
 ]
 
 { #category : #accessing }

--- a/src/Kendrick/KEComponent.class.st
+++ b/src/Kendrick/KEComponent.class.st
@@ -164,7 +164,7 @@ KEComponent >> equationsToTransitions [
 	events
 		do: [ :e | 
 			e fromStatus = #empty
-				ifTrue: [  e rate: (e rate remove: (KEVariable new symbol: #N)) ] ].
+				ifTrue: [ e rate: (e rate removeVariable: (KEVariable new symbol: #N)) ] ].
 	events
 		do: [ :each | 
 			| from to |
@@ -211,24 +211,29 @@ KEComponent >> initialize [
 { #category : #'generating events' }
 KEComponent >> mergeEventsWithSameActionsIn: eventList [
 	"This function will find all events with same actions and merge their rate in one event"
-	|newList|
-	newList := OrderedCollection new.
-	eventList do: [ :event|
-		(event hasAnEventWithSameActionsIn: newList)
-		ifTrue: [ |e|
-			e := event findEventWithSameActionsIn: newList.
-			e rate: ((KEBinaryExpression new) op: #+; leftHandSide: (e rate); rightHandSide: (event rate))
-			 ]
-		ifFalse: [ newList add: event ].
-		 ].
-	newList do: [ :each|
-		(each fromStatus = #empty) 
-		"ifTrue: [
-			each rate: (each rate remove: (KEVariable new symbol: #N)) ]"
-		ifFalse: [ each rate: (each rate remove: (KEVariable new symbol: each fromStatus)) ]
-		 ].
-	^ newList
 
+	| newList |
+	newList := OrderedCollection new.
+	eventList
+		do: [ :event | 
+			(event hasAnEventWithSameActionsIn: newList)
+				ifTrue: [ | e |
+					e := event findEventWithSameActionsIn: newList.
+					e
+						rate:
+							(KEBinaryExpression new
+								op: #+;
+								leftHandSide: e rate;
+								rightHandSide: event rate) ]
+				ifFalse: [ newList add: event ] ].
+	newList
+		do: [ :each | 
+			each fromStatus = #empty
+				ifFalse: [ each
+						rate: (each rate removeVariable: (KEVariable new symbol: each fromStatus)) ]
+			"ifTrue: [
+			each rate: (each rate remove: (KEVariable new symbol: #N)) ]" ].
+	^ newList
 ]
 
 { #category : #parameters }

--- a/src/Kendrick/KEExpression.class.st
+++ b/src/Kendrick/KEExpression.class.st
@@ -69,6 +69,11 @@ KEExpression >> negated [
 ]
 
 { #category : #testing }
+KEExpression >> removeVariable: aVariable [
+	self subclassResponsibility
+]
+
+{ #category : #testing }
 KEExpression >> value: model [
 	^ self evaluateWithModel: model
 ]

--- a/src/Kendrick/KEExpressionTest.class.st
+++ b/src/Kendrick/KEExpressionTest.class.st
@@ -196,43 +196,61 @@ self assert: '-beta' equals: minusBeta asString.
 
 { #category : #tests }
 KEExpressionTest >> testRemoveAVariableFromABinaryExpression [
-	|e n|
-	e := (KEBinaryExpression new op: #*;leftHandSide: (KEVariable new symbol:#S);rightHandSide: (KEMathFunctionExpression new functionName: #cos; functionExpr: (KEVariable new symbol: #t))).
-	n := e remove: (KEVariable new symbol: #S).
+	| e n |
+	e := KEBinaryExpression new
+		op: #*;
+		leftHandSide: (KEVariable new symbol: #S);
+		rightHandSide:
+			(KEMathFunctionExpression new
+				functionName: #cos;
+				functionExpr: (KEVariable new symbol: #t)).
+	n := e removeVariable: (KEVariable new symbol: #S).
 	self assert: n isExpressionWithMathFunction equals: true.
-	self assert: n equals: (KEMathFunctionExpression new functionName: #cos; functionExpr: (KEVariable new symbol: #t)).
-	
+	self
+		assert: n
+		equals:
+			(KEMathFunctionExpression new
+				functionName: #cos;
+				functionExpr: (KEVariable new symbol: #t))
 ]
 
 { #category : #tests }
 KEExpressionTest >> testRemoveAVariableFromANumber [
-	|e n|
-	e := (KENumerical new number: 200).
-	n := e remove: (KEVariable new symbol: #S).
-	self assert: n equals: (KENumerical new number: 200).
-	
+	"don't understand the meaning of this test"
+
+	| e n |
+	e := KENumerical new number: 200.
+	n := e removeVariable: (KEVariable new symbol: #S).
+	self assert: n equals: (KENumerical new number: 200)
 ]
 
 { #category : #tests }
 KEExpressionTest >> testRemoveAVariableFromAVariable [
-	|e n|
-	e := (KEVariable new symbol: #S).
-	n := e remove: (KEVariable new symbol: #S).
-	self assert: n equals: nil.
-	
+	| e n |
+	e := KEVariable new symbol: #S.
+	n := e removeVariable: (KEVariable new symbol: #S).
+	self assert: n equals: nil
 ]
 
 { #category : #tests }
 KEExpressionTest >> testRemoveAVariableFromAnUnaryExpression [
-	|e n|
-	e := (KEUnaryExpression new) op:#-; expression: (KEVariable new symbol: #S).
-	n := e remove: (KEVariable new symbol: #S).
+	| e n |
+	e := KEUnaryExpression new
+		op: #-;
+		expression: (KEVariable new symbol: #S).
+	n := e removeVariable: (KEVariable new symbol: #S).
 	self assert: n isUnaryExpression equals: true.
 	self assert: n expression equals: nil.
-	e := (KEUnaryExpression new) op: #-; expression: (KEBinaryExpression new op:#*;leftHandSide: (KEVariable new symbol: #S);rightHandSide: (KEVariable new symbol: #I)).
-	n := e remove: (KEVariable new symbol: #S).
+	e := KEUnaryExpression new
+		op: #-;
+		expression:
+			(KEBinaryExpression new
+				op: #*;
+				leftHandSide: (KEVariable new symbol: #S);
+				rightHandSide: (KEVariable new symbol: #I)).
+	n := e removeVariable: (KEVariable new symbol: #S).
 	self assert: n isUnaryExpression equals: true.
-	self assert: n expression equals: (KEVariable new symbol: #I).
+	self assert: n expression equals: (KEVariable new symbol: #I)
 ]
 
 { #category : #tests }

--- a/src/Kendrick/KEIndexedVariable.class.st
+++ b/src/Kendrick/KEIndexedVariable.class.st
@@ -100,17 +100,18 @@ KEIndexedVariable >> printOn: aStream [
 				nextPutAll: ']' ]
 ]
 
-{ #category : #removing }
-KEIndexedVariable >> remove: aVariable [
-	self symbol = aVariable symbol ifTrue: [ ^ nil ].
-	^ self
-		
-	
-]
-
 { #category : #evaluating }
 KEIndexedVariable >> removeIndexedVariable [
 	^ (KEVariable new symbol: symbol)
 		
 	
+]
+
+{ #category : #removing }
+KEIndexedVariable >> removeVariable: aVariable [
+	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
+
+	self symbol = aVariable symbol
+		ifTrue: [ ^ nil ].
+	^ self
 ]

--- a/src/Kendrick/KEMathFunctionExpression.class.st
+++ b/src/Kendrick/KEMathFunctionExpression.class.st
@@ -97,18 +97,19 @@ KEMathFunctionExpression >> printOn: aStream [
 		nextPutAll: ')'
 ]
 
-{ #category : #removing }
-KEMathFunctionExpression >> remove: aVariable [
-	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
-	^ self
-]
-
 { #category : #evaluating }
 KEMathFunctionExpression >> removeIndexedVariable [
 	|new|
 	new := self copy.
 	new functionExpr: functionExpr removeIndexedVariable.
 	^ new
+]
+
+{ #category : #removing }
+KEMathFunctionExpression >> removeVariable: aVariable [
+	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
+
+	^ self
 ]
 
 { #category : #acessing }

--- a/src/Kendrick/KENumerical.class.st
+++ b/src/Kendrick/KENumerical.class.st
@@ -69,14 +69,15 @@ KENumerical >> printOn: aStream [
 ]
 
 { #category : #evaluating }
-KENumerical >> remove: aVariable [
-	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
+KENumerical >> removeIndexedVariable [
 	^ self
 ]
 
 { #category : #evaluating }
-KENumerical >> removeIndexedVariable [
-	^ self
+KENumerical >> removeVariable: aVariable [
+	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
+
+	
 ]
 
 { #category : #evaluating }

--- a/src/Kendrick/KEUnaryExpression.class.st
+++ b/src/Kendrick/KEUnaryExpression.class.st
@@ -101,9 +101,11 @@ KEUnaryExpression >> negated [
 
 { #category : #converting }
 KEUnaryExpression >> normalize [
-	|e|
+	| e |
 	e := expression normalize.
-	e isUnaryExpression ifTrue: [^ (e expression)] ifFalse: [^ ((KEUnaryExpression new) op: #-; expression: e)].
+	e isUnaryExpression
+		ifTrue: [ ^ e expression ]
+		ifFalse: [ ^ (self op: #-) expression: e ]
 ]
 
 { #category : #accessing }
@@ -123,15 +125,6 @@ KEUnaryExpression >> printOn: aStream [
 		nextPutAll: expression asString
 ]
 
-{ #category : #removing }
-KEUnaryExpression >> remove: aVariable [
-	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
-	|new|
-	new := (KEUnaryExpression new) op: #-.
-	new expression: (expression remove: aVariable).
-	^ new
-]
-
 { #category : #evaluating }
 KEUnaryExpression >> removeIndexedVariable [
 	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
@@ -139,6 +132,13 @@ KEUnaryExpression >> removeIndexedVariable [
 	new := self copy.
 	new expression: (expression removeIndexedVariable).
 	^ new
+]
+
+{ #category : #removing }
+KEUnaryExpression >> removeVariable: aVariable [
+	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
+
+	^ (self op: #-) expression: (expression removeVariable: aVariable)
 ]
 
 { #category : #testing }

--- a/src/Kendrick/KEVariable.class.st
+++ b/src/Kendrick/KEVariable.class.st
@@ -72,17 +72,17 @@ KEVariable >> printOn: aStream [
 		nextPutAll: symbol asString
 ]
 
+{ #category : #evaluating }
+KEVariable >> removeIndexedVariable [
+	^ self
+]
+
 { #category : #removing }
-KEVariable >> remove: aVariable [
+KEVariable >> removeVariable: aVariable [
 	"This function is reserved for the reformulation of rate expression to probability of contact of an event generated from an equation"
 
 	self = aVariable
 		ifTrue: [ ^ nil ]
-]
-
-{ #category : #evaluating }
-KEVariable >> removeIndexedVariable [
-	^ self
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Rename remove: as removeVariable: in order to be able to use senders/implementors search more easily.
Before more deep refactoring of these methods.