### PR TITLE
Fix #310

### DIFF
--- a/src/Kendrick/KETransition.class.st
+++ b/src/Kendrick/KETransition.class.st
@@ -52,6 +52,8 @@ KETransition >> from: aCompartment [
 
 	| reader |
 	aCompartment isDictionary ifTrue: [ ^ from := aCompartment ].
+		aCompartment = #empty
+		ifTrue: [ ^ self from: {(#status -> #empty)} ].
 	aCompartment isArray ifTrue: [ 
 		^ from := Dictionary newFrom: aCompartment ].
 	(reader := STONReader on: aCompartment readStream) 
@@ -98,6 +100,7 @@ KETransition >> to: aCompartment [
 
 	| reader |
 	aCompartment isDictionary ifTrue: [ ^ to := aCompartment ].
+		aCompartment = #empty ifTrue: [ ^ self to: { #status -> #empty } ].
 	aCompartment isArray ifTrue: [ 
 		^ to := Dictionary newFrom: aCompartment ].
 	(reader := STONReader on: aCompartment readStream) 

--- a/src/Kendrick/Visualization.class.st
+++ b/src/Kendrick/Visualization.class.st
@@ -160,6 +160,11 @@ Visualization >> dataWithSimpleCompartments: anArray [ "should be full math-expr
 			
 ]
 
+{ #category : #'public-api' }
+Visualization >> diagram [
+	^ self with: KEChart
+]
+
 { #category : #'as yet unclassified' }
 Visualization >> expand: prefix forLists: lists [
 
@@ -201,8 +206,8 @@ RSPNGExporter new
 		export."
 		
 		canvas: c;
-		exportToFile: filePath asFileReference
-	"^ self canvas"
+		exportToFile: filePath asFileReference.
+	^ self open
 ]
 
 { #category : #'public-api' }


### PR DESCRIPTION
Revert KETransition from:to: to previous version.
STON support should be deprecated in the future.
Missing diagram method in Visualisation
Visualization window was not opening anymore